### PR TITLE
Move district heading above communes grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
     
     <section class="comunas">
         <div class="container">
-            
+            <h3>Comunas del Distrito</h3>
             <div class="comunas-grid">
                 <div class="comuna">
                     <img src="img/comuna_1.png" alt="Comuna 1">
@@ -68,12 +68,6 @@
                     <p>Comuna 6</p>
                 </div>
             </div>
-        </div>
-    </section>
-    
-        <div class="container">
-            <h3>Comunas del Distrito</h3>
-            
         </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Show "Comunas del Distrito" above the communes grid so it acts as a title for all communes

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden to fetch package)*

------
https://chatgpt.com/codex/tasks/task_e_68b538d1f5f88327835b487847e09d2d