### PR TITLE
Add blurred Chile flag background

### DIFF
--- a/img/chile_flag.svg
+++ b/img/chile_flag.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3 2">
+  <rect width="3" height="2" fill="#fff"/>
+  <rect y="1" width="3" height="1" fill="#d52b1e"/>
+  <rect width="1.5" height="1" fill="#0039a6"/>
+  <polygon fill="#fff" points="0.750,0.200 0.817,0.407 1.035,0.407 0.859,0.535 0.926,0.743 0.750,0.615 0.574,0.743 0.641,0.535 0.465,0.407 0.683,0.407"/>
+</svg>

--- a/style.css
+++ b/style.css
@@ -42,8 +42,21 @@ body {
     font-weight: bold;
 }
 .hero {
-    background: #e5e5e5;
+    position: relative;
     padding: 40px 0;
+    overflow: hidden;
+    background: #e5e5e5;
+}
+
+.hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: url('img/chile_flag.svg') center / cover no-repeat;
+    filter: blur(8px);
+    transform: scale(1.1);
+    opacity: 0.4;
+    z-index: -1;
 }
 .hero-flex {
     display: flex;


### PR DESCRIPTION
## Summary
- Show a blurred Chile flag behind the hero section to highlight the candidate
- Include an SVG Chile flag asset for the background

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b53d8ffd388327b412b88a4b4c2274